### PR TITLE
Fix (error: (wrong-type-argument package-desc nil))

### DIFF
--- a/git-complete.el
+++ b/git-complete.el
@@ -1,4 +1,4 @@
-;;; git-complete.el -- Yet another completion engine powered by "git grep"
+;;; git-complete.el --- Yet another completion engine powered by "git grep"
 
 ;; Copyright (C) 2017- zk_phi
 


### PR DESCRIPTION
![screen shot 2017-09-03 at 18 29 10](https://user-images.githubusercontent.com/2087334/30001898-d58b8cee-90d6-11e7-9b85-fc877f008201.png)

パッケージの書式に関するエラーがありましたので修正箇所をご報告します。

    An error occurred while installing git-complete (error: (wrong-type-argument package-desc nil))

git-complete.el: 1行目に3つのハイフンがない場合にSpacemacsではエラーが出てインストールが失敗するようです。

* Spacemacs v.0.200.9
* Ubuntu 16.04.3
* GNU Emacs 25.2.2 (x86_64-pc-linux-gnu, GTK+ Version 3.18.9) of 2017-05-07
